### PR TITLE
Add DataSourceRequest and implement overload on ToDataSourceResult.

### DIFF
--- a/Kendo.DynamicLinq/DataSourceRequest.cs
+++ b/Kendo.DynamicLinq/DataSourceRequest.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Kendo.DynamicLinq
+{
+    /// <summary>
+    /// Describes a Kendo Datasource request.
+    /// </summary>
+    public class DataSourceRequest
+    {
+        /// <summary>
+        /// Specifies how many items to take.
+        /// </summary>
+        public int Take { get; set; }
+
+        /// <summary>
+        /// Specifies how many items to skip.
+        /// </summary>
+        public int Skip { get; set; }
+
+        /// <summary>
+        /// Specifies the requested sort order.
+        /// </summary>
+        public IEnumerable<Sort> Sort { get; set; }
+
+        /// <summary>
+        /// Specifies the requested filter.
+        /// </summary>
+        public Filter Filter { get; set; }
+    }
+}

--- a/Kendo.DynamicLinq/Kendo.DynamicLinq.csproj
+++ b/Kendo.DynamicLinq/Kendo.DynamicLinq.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Aggregate.cs" />
+    <Compile Include="DataSourceRequest.cs" />
     <Compile Include="DataSourceResult.cs" />
     <Compile Include="Filter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Kendo.DynamicLinq/QueryableExtensions.cs
+++ b/Kendo.DynamicLinq/QueryableExtensions.cs
@@ -12,7 +12,7 @@ namespace Kendo.DynamicLinq
 		/// <summary>
 		/// Applies data processing (paging, sorting, filtering and aggregates) over IQueryable using Dynamic Linq.
 		/// </summary>
-		/// <typeparam name="T">The type of the IQueryable</typeparam>
+		/// <typeparam name="T">The type of the IQueryable.</typeparam>
 		/// <param name="queryable">The IQueryable which should be processed.</param>
 		/// <param name="take">Specifies how many items to take. Configurable via the pageSize setting of the Kendo DataSource.</param>
 		/// <param name="skip">Specifies how many items to skip.</param>
@@ -51,7 +51,7 @@ namespace Kendo.DynamicLinq
 		/// <summary>
 		/// Applies data processing (paging, sorting and filtering) over IQueryable using Dynamic Linq.
 		/// </summary>
-		/// <typeparam name="T">The type of the IQueryable</typeparam>
+		/// <typeparam name="T">The type of the IQueryable.</typeparam>
 		/// <param name="queryable">The IQueryable which should be processed.</param>
 		/// <param name="take">Specifies how many items to take. Configurable via the pageSize setting of the Kendo DataSource.</param>
 		/// <param name="skip">Specifies how many items to skip.</param>
@@ -62,6 +62,18 @@ namespace Kendo.DynamicLinq
 		{
 			return queryable.ToDataSourceResult(take, skip, sort, filter, null);
 		}
+
+        /// <summary>
+        ///  Applies data processing (paging, sorting and filtering) over IQueryable using Dynamic Linq.
+        /// </summary>
+        /// <typeparam name="T">The type of the IQueryable.</typeparam>
+        /// <param name="queryable">The IQueryable which should be processed.</param>
+        /// <param name="request">The DataSourceRequest object containing take, skip, order, and filter data.</param>
+        /// <returns>A DataSourceResult object populated from the processed IQueryable.</returns>
+	    public static DataSourceResult ToDataSourceResult<T>(this IQueryable<T> queryable, DataSourceRequest request)
+	    {
+	        return queryable.ToDataSourceResult(request.Take, request.Skip, request.Sort, request.Filter, null);
+	    }
 
 		private static IQueryable<T> Filter<T>(IQueryable<T> queryable, Filter filter)
 		{


### PR DESCRIPTION
I have added a DataSourceRequest POCO to simplify the obvious use of the DLinq Helpers in ASP.NET Web API (and maybe also ASP.NET MVC by using appropriate model binding). This simplifies the use on Web API controllers to:

``` csharp
[HttpPost]
public IHttpActionResult GetMyResources(DataSourceRequest request)
{
    var myResources = _repository.GetAll;
    return Ok(myResources.ToDataSourceResult(request));
}
```

Just a shortcut to prevent mapping out the take, skip, order, and filter parameters and passing them one-on-one to the ToDataSourceResult extension method.
