### PR TITLE
Allowing ToExpression to be overwritable, 

### DIFF
--- a/Kendo.DynamicLinq/Filter.cs
+++ b/Kendo.DynamicLinq/Filter.cs
@@ -91,7 +91,7 @@ namespace Kendo.DynamicLinq
         /// Converts the filter expression to a predicate suitable for Dynamic Linq e.g. "Field1 = @1 and Field2.Contains(@2)"
         /// </summary>
         /// <param name="filters">A list of flattened filters.</param>
-        public string ToExpression(IList<Filter> filters)
+        public virtual string ToExpression(IList<Filter> filters)
         {
             if (Filters != null && Filters.Any())
             {

--- a/Kendo.DynamicLinq/Sort.cs
+++ b/Kendo.DynamicLinq/Sort.cs
@@ -25,7 +25,7 @@ namespace Kendo.DynamicLinq
         /// <summary>
         /// Converts to form required by Dynamic Linq e.g. "Field1 desc"
         /// </summary>
-        public string ToExpression()
+        public virtual string ToExpression()
         {
             return Field + " " + Dir;
         }


### PR DESCRIPTION
Hi,

I am using the package https://www.nuget.org/packages/System.Linq.Dynamic.Library/ , in my approach for implementing some filter logic I'd like to support "in" operator. For example, the client sends a filter instance:

{ field:"CountryId",  operator: "in", value:"[1,2,3]" }

The ToExpression method generates an invalid string for the Dynamic LINQ. Thus, I'd like to implement a subsclass which deals with this specific situation for me and it should be able to create something like:
"new List<int>() {1,2,3}.Contains(CountryId)"

NOTE:  Not sure if there is a better alternative other than creating the List as part of the Where clause.

Just in case, if the input were: 
{ field:"CountryId",  operator: "contains", value:"[1,2,3]" }, 
then the generated expression would be:
"CountryId.Contains([1,2,3])"
but this is incorrect because the goal is the check the the array contains the CountryId, not the other way around)

In any case, my idea with this change is like subclasses can add support to custom filter options, just by being able of overriding the ToExpression method.
